### PR TITLE
fix: make getting started guide more beginner friendly

### DIFF
--- a/overview/getting-started.md
+++ b/overview/getting-started.md
@@ -23,6 +23,11 @@ The very basic configuration consists of two steps: _HTTP listener_ definition a
 {% code-tabs %}
 {% code-tabs-item title="http.listener.ts" %}
 ```typescript
+import { httpListener } from '@marblejs/core';
+import { logger$ } from '@marblejs/middleware-logger';
+import { bodyParser$ } from '@marblejs/middleware-body';
+import { api$ } from './api.effects';
+
 const middlewares = [
   logger$(),
   bodyParser$(),
@@ -30,12 +35,30 @@ const middlewares = [
 ];
 
 const effects = [
-  endpoint1$,
-  endpoint2$,
+  api$,
+  // endpoint2$
   // ...
 ];
 
 export default httpListener({ middlewares, effects });
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
+then we define our basic `api` effect which responds with "hello world" string.  
+
+{% code-tabs %}
+{% code-tabs-item title="api.effects.ts" %}
+```typescript
+import { r } from '@marblejs/core';
+import { mapTo } from 'rxjs/operators';
+
+export const api$ = r.pipe(
+  r.matchPath('/'),
+  r.matchType('GET'),
+  r.useEffect(req$ => req$.pipe(
+     mapTo({ body: 'Hello, world!' }),
+  )));
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
@@ -57,7 +80,32 @@ export const server = createServer({
 server.run();
 ```
 {% endcode-tabs-item %}
-{% endcode-tabs %}
+{% endcode-tabs %}  
+
+{% hint style="info" %}
+you can always visit [example repository](https://github.com/marblejs/example) for a complete Marble.js app example. 
+{% endhint %}
+
+We'll use [TypeScript](https://www.typescriptlang.org/) in the documentation but you can always write Marble apps in standard JavaScript (and any other language that transpiles to JavaScript). 
+
+To test run your server you can install `typescript` compiler and `ts-node`:  
+```bash
+$ yarn add typescript ts-node
+```  
+
+then add the following script to your `package.json` file:  
+```JSON
+"scripts": {
+  "start": "ts-node index.ts"
+}
+```
+
+Now go ahead, create `server.ts`, `http.listener.ts`, `api.effects.ts` modules in your project and run your server:  
+```bash
+$ yarn start
+```
+
+finally test your "functional" server by visiting [http://localhost:1337]()
 
 {% hint style="info" %}
 For more API specific details about server bootstraping, visit [createServer](../api-reference/core/createserver.md) API reference.

--- a/overview/getting-started.md
+++ b/overview/getting-started.md
@@ -45,7 +45,7 @@ export default httpListener({ middlewares, effects });
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-then we define our basic `api` effect which responds with "hello world" string.  
+And here is our simple "hello world" endpoint.  
 
 {% code-tabs %}
 {% code-tabs-item title="api.effects.ts" %}
@@ -131,4 +131,3 @@ export const server = http
 {% endcode-tabs %}
 
 In the next chapter you will learn how to create basic **Marble.js** endpoints using [Effects](effects.md).
-


### PR DESCRIPTION
I think a complete getting started guide creates a very good first impression on beginners.  
It is very encouraging when you can start your project just by copy-pasting the tutorial before going on an extensive documentation tour.  
Here I added: 
  - Some missing `import` statements for httpListener and RXJS operators
  - The hello world `effect` (hopefully Observable API will be so intuitive that I think beginners will start to play with the example before knowing anything about Observables, etc)
  - I added a link to super helpful example repository
  - I think Marble has a major advantage not relying on experimental language features (or TypeScript specific ones) like decorators. So we practically can write Marble apps using standard JavaScript or any language that transpiles to JS (Marble apps look beautiful in functional languages like [PureScript](http://www.purescript.org/), [LiveScript](http://livescript.net/) and [ReasonML](https://reasonml.github.io/) that have pipe (|>) operator) so I mentioned this.