### PR TITLE
fix typos and improve wording, grammar

### DIFF
--- a/overview/effects.md
+++ b/overview/effects.md
@@ -10,9 +10,9 @@ const helloEffect$: HttpEffect = req$ => req$.pipe(
 );
 ```
 
-The _Effect_ above responds to incoming request with `Hello, world!` message. In Marble.js, every _Effect_ tries to be referentailly transparent, which means that each incoming request has to be mapped to object with attributes like `body`, `status` or `headers`. If the _status_ code or _headers_ are not defined, then API by default responds with _200_ status and _application/json_ header.
+The _Effect_ above responds to incoming request with `Hello, world!` message. In Marble.js, every _Effect_ tries to be referentailly transparent, which means that each incoming request has to be mapped to an object with attributes like `body`, `status` or `headers`. If the _status_ code or _headers_ are not defined, then the API by default responds with _200_ status and _application/json_ header.
 
-In order to route our first _Effect,_ we have to define the path and HTTP method that the incoming request should be matched to. The simplest implementation of HTTP API endpoint can look like in example below.
+In order to route our first _Effect,_ we have to define the path and HTTP method that the incoming request should be matched to. The simplest implementation of an HTTP API endpoint can look like this.
 
 {% code-tabs %}
 {% code-tabs-item title="effect-with-pipe.ts" %}
@@ -74,7 +74,7 @@ Since Marble.js 2.0, you can build HTTP API routes using [`EffectFactory`](../ap
 
 ## HttpRequest
 
-Every _HttpEffect_ has an access to two most basics objects created by _http.Server_. **HttpRequest** is an abstraction over basic _Node.js_ [http.IncomingMessage](https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_class_http_incomingmessage) object. It may be used to access response status, headers and data, but in most scenarios you don't have to deal with all available APIs offered by _IncomingMessage_ class. The most common properties available in request object are:
+Every _HttpEffect_ has an access to two most basics objects created by _http.Server_. **HttpRequest** is an abstraction over the basic _Node.js_ [http.IncomingMessage](https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_class_http_incomingmessage) object. It may be used to access response status, headers and data, but in most scenarios you don't have to deal with all available APIs offered by _IncomingMessage_ class. The most common properties available in request object are:
 
 * _url_
 * _method_
@@ -89,9 +89,9 @@ For more details about available API offered in `http.IncomingMessage`, please v
 
 ## HttpResponse
 
-Like previously described _HttpRequest_, the **HttpResponse** object is also an abstraction over basic _Node.js_ [http.ServerResponse](https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_class_http_serverresponse) object. Besides the default API, the response object exposes an `res.send` method, which can be a handy wrapper over _Marble.js_ responding mechanism. For more detailed information about _res.send_ method, visit [Middlewares](middlewares.md#sending-a-response-earlier) chapter.
+Like the previously described _HttpRequest_, the **HttpResponse** object is also an abstraction over basic _Node.js_ [http.ServerResponse](https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_class_http_serverresponse) object. Besides the default API, the response object exposes an `res.send` method, which can be a handy wrapper over _Marble.js_ responding mechanism. For more information about the _res.send_ method, visit [Middlewares](middlewares.md#sending-a-response-earlier) chapter.
 
 {% hint style="info" %}
-For more details about available API offered in `http.ServerResponse`, please visit [official Node.js docummentation](https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_class_http_serverresponse).
+For more details about the available API offered in `http.ServerResponse`, please visit [official Node.js docummentation](https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_class_http_serverresponse).
 {% endhint %}
 

--- a/overview/error-handling.md
+++ b/overview/error-handling.md
@@ -21,9 +21,9 @@ const authorize$: HttpMiddlewareEffect = req$ =>
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-_Marble.js comes with dedicated `HttpError`_ class for defining a request related errors that can be catched easily via error middleware. Using _RxJS_ built-in `throwError` method, we can throw an error and catch it on an upper level \(eg. directly inside _Effect_ or _ErrorEffect_\).
+_Marble.js comes with a dedicated `HttpError`_ class for defining request related errors that can be caught easily via error middleware. Using the _RxJS_ built-in `throwError` method, we can throw an error and catch it on an upper level \(e.g. directly inside _Effect_ or _ErrorEffect_\).
 
-`HttpError` class resides in `@marblejs/core` package. The constructor takes as a first parameter an error message and as a second parameter a `HttpStatus` code that can be a plain _JavaScript_ `number` or _TypeScript_ enum type that can also be imported via core package. Optionally you can pass the third argument, which can contain any other error related values.
+The `HttpError` class resides in the `@marblejs/core` package. The constructor takes as a first parameter an error message and as a second parameter a `HttpStatus` code that can be a plain _JavaScript_ `number` or _TypeScript_ enum type that can also be imported via core package. Optionally you can pass the third argument, which can contain any other error related values.
 
 ```typescript
 new HttpError('Forbidden', HttpStatus.FORBIDDEN, { resource: 'index.html' });

--- a/overview/how-does-it-fit-together.md
+++ b/overview/how-does-it-fit-together.md
@@ -2,7 +2,7 @@
 
 Writing REST API in Marble.js isn't hard as you might think. The developer has to understand mostly only the main building block which is the _Effect_ and how the data flows through it.
 
-The aim of this chapter is to demonstrate how building blocks described in previous chapters glue together. For ease of understaning lets build a tiny RESTful API for users handling. Lets omit the implementation details of database access and focus only on the Marble.js related things.
+The aim of this chapter is to demonstrate how building blocks described in previous chapters glue together. For ease of understaning lets build a tiny RESTful API for user handling. Lets omit the implementation details of database access and focus only on the Marble.js related things.
 
 ```typescript
 import { createServer, combineRoutes, httpListener, r, HttpError, use } from '@marblejs/core';

--- a/overview/middlewares.md
+++ b/overview/middlewares.md
@@ -4,7 +4,7 @@ It is a common requirement to encounter the necessity of having various operatio
 
 ## Building your own middleware
 
-Because everything here is a stream, also plugged-in middlewares are based on similar _Effect_ interface. By default, framework comes with composable middlewares like: [logging](../api-reference/middleware-logger.md), request [body parsing](../api-reference/middleware-body.md) or request [validator](../api-reference/middleware-io.md). Below you can see how simple can look the dummy HTTP request logging middleware.
+Because everything here is a stream, the plugged-in middlewares are also based on a similar _Effect_ interface. By default, framework comes with composable middlewares like: [logging](../api-reference/middleware-logger.md), request [body parsing](../api-reference/middleware-body.md) or request [validator](../api-reference/middleware-io.md). Below you can see how simple can a dummy HTTP request logging middleware look.
 
 ```typescript
 const logger$ = (req$: Observable<HttpRequest>, res: HttpResponse): Observable<HttpRequest> =>
@@ -13,9 +13,9 @@ const logger$ = (req$: Observable<HttpRequest>, res: HttpResponse): Observable<H
   );
 ```
 
-In the example above we get the stream of requests, then tap the `console.log` side effect and returns the same stream as a response of our middleware pipeline. The middleware, in comparison to basic effect, must return the request at the end.
+In the example above we get a stream of requests, then tap the `console.log` side effect and return the same stream as a response from our middleware pipeline. The middleware, compared to the basic effect, must return the request at the end.
 
-If you prefer shorter type definitions, you can use a `HttpMiddlewareEffect` function interface.
+If you prefer shorter type definitions, you can use the `HttpMiddlewareEffect` function interface.
 
 ```typescript
 const logger$: HttpMiddlewareEffect = (req$, res) =>
@@ -24,7 +24,7 @@ const logger$: HttpMiddlewareEffect = (req$, res) =>
   );
 ```
 
-In order to use our custom middleware, what we need to do is to attach the defined middleware to `httpListener` config.
+In order to use our custom middleware, we need to attach the defined middleware to the `httpListener` config.
 
 ```typescript
 const middlewares = [
@@ -37,7 +37,7 @@ const app = httpListener({ middlewares, effects });
 
 ### Parameterized middleware
 
-There are some cases when our custom middleware needs to be parameterized - for example dummy _logger$_ middleware should _console.log_ request URL's conditionally. To achieve this behavior we have to make our middleware function _curried_, where the last returned function should conform to`HttpMiddlewareEffect` interface.
+There are some cases when our custom middleware needs to be parameterized - for example, the dummy _logger$_ middleware should _console.log_ request URL's conditionally. To achieve this behavior we can make our middleware function _curried_, where the last returned function should conform to`HttpMiddlewareEffect` interface.
 
 ```typescript
 interface LoggerOpts {
@@ -61,7 +61,7 @@ const middlewares = [
 
 ### Sending a response earlier
 
-Some types of middlewares need to send a HTTP response earlier. In this case Marble.js exposes a dedicated `res.send` method which allows to send a HTTP response using the same common interface that we use for sending a response inside API _Effects_. The mentioned method returns an empty _Observable_ \(_Observable that immediately completes_\) as a result, so it can be composed easily inside middleware pipeline.
+Some types of middlewares need to send an HTTP response earlier. For this case Marble.js exposes a dedicated `res.send` method which allows to send an HTTP response using the same common interface that we use for sending a response inside API _Effects_. The mentioned method returns an empty _Observable_ \(_Observable that immediately completes_\) as a result, so it can be composed easily inside a middleware pipeline.
 
 ```typescript
 const middleware$: HttpMiddlewareEffect = (req$, res) =>
@@ -131,7 +131,7 @@ As you probably noticed, `auth.middleware` introduces an example use case of err
 
 ### via _combineRoutes_
 
-There are some cases where you have to compose a bunch of middlewares before grouped routes, eg. to authorize only a selecteted group of endpoints. Instead of composing middlewares for each route separately, using [use operator](../api-reference/core/operator-use.md), you can also compose them via extended second parameter in`combineRoutes()` function.
+There are some cases where you have to compose a bunch of middlewares before grouped routes, e.g. to authorize only a selected group of endpoints. Instead of composing middlewares for each route separately, using [use operator](../api-reference/core/operator-use.md), you can also compose them via the extended second parameter in`combineRoutes()` function.
 
 ```typescript
 const api$ = combineRoutes('api/v1', {
@@ -142,7 +142,7 @@ const api$ = combineRoutes('api/v1', {
 
 ### via _httpListener_
 
-If your middleware should operate globally, eg. in case of request logging, the best place is to compose it inside `httpListener`. In this case the middleware will operate for each request that will go through your HTTP server.
+If your middleware should operate globally, e.g. in case of request logging, the best place is to compose it inside `httpListener`. In this case the middleware will operate on each request that goes through your HTTP server.
 
 ```typescript
 const middlewares = [

--- a/overview/routing.md
+++ b/overview/routing.md
@@ -12,7 +12,7 @@ description: >-
 As we know - every API requires composable routing. Lets assume that we have a separate **User** feature where its API endpoints respond to _GET_ and _POST_ methods on `/user` path.
 
 {% hint style="info" %}
-Since Marble.js. v2.0, you can choose between two ways of defining HTTP routes - using [`EffectFactory`](../api-reference/core/core-effectfactory.md) or using [`r.pipe`](../api-reference/core/r.pipe.md) operators. For example purposes lets stick to the second, newest way, which has more functional flavor and is more composable.
+Since Marble.js. v2.0, you can choose between two ways of defining HTTP routes - using [`EffectFactory`](../api-reference/core/core-effectfactory.md) or using [`r.pipe`](../api-reference/core/r.pipe.md) operators. In this example we will stick to the second, newer way, which has a more functional flavor and is more composable.
 {% endhint %}
 
 `r.pipe` is an indexed monad builder used for collecting information about Marble REST route details, like: _path_, request _method type_, _middlewares_ and connected _Effect_.
@@ -44,7 +44,7 @@ export const user$ = combineRoutes(
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-Defined _HttpEffects_ can be grouped together using `combineRoutes` function, which combines routing for prefixed path passed as a first argument. Exported group of _Effects_ can be combined with other _Effects_ like in the example below.
+Defined _HttpEffects_ can be grouped together using `combineRoutes` function, which combines routing for a prefixed path passed as a first argument. Exported group of _Effects_ can be combined with other _Effects_ like in the example below.
 
 {% code-tabs %}
 {% code-tabs-item title="api.effects.ts" %}
@@ -74,7 +74,7 @@ export const api$ = combineRoutes(
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-As you can see, previously defined routes can be combined together, so as a result the routing is built in much more structured way. If we analyze the above example, the routing will be mapped to the following routing table.
+As you can see, the previously defined routes can be combined together, so as a result the routing is built in a much more structured way. If we analyze the above example, the routing will be mapped to the following routing table.
 
 ```text
 GET    /api/v1
@@ -83,7 +83,7 @@ GET    /api/v1/user
 POST   /api/v1/user
 ```
 
-There are some cases where there is a need to compose a bunch of middlewares before grouped routes, eg. to authenticate requests only for a selecteted group of endpoints. Instead of composing middlewares using [use operator](../api-reference/core/operator-use.md) for each route separately, you can compose them via extended second parameter in`combineRoutes()` function.
+There are some cases where there is a need to compose a bunch of middlewares before grouped routes, e.g. to authenticate requests only for a selected group of endpoints. Instead of composing middlewares using [use operator](../api-reference/core/operator-use.md) for each route separately, you can compose them via the extended second parameter in`combineRoutes()` function.
 
 ```typescript
 const user$ = combineRoutes('/user', {
@@ -94,14 +94,14 @@ const user$ = combineRoutes('/user', {
 
 ## Body parameters
 
-Marble.js doesn't come with build-in mechanism for parsing _POST_, _PUT_ and _PATCH_ request bodies. In order to get parsed request body you can use dedicated _@marblejs/middleware-body_ package. A new `req.body` object containing the parsed data will populated on the request object after the middleware, or undefined if there was no body to parse, the `Content-Type` was not matched, or an error occurred. To learn more about body parsing middleware visit the [@marblejs/middleware-body](../api-reference/middleware-body.md) API specification.
+Marble.js doesn't come with a built-in mechanism for parsing _POST_, _PUT_ and _PATCH_ request bodies. In order to get the parsed request body you can use dedicated _@marblejs/middleware-body_ package. A new `req.body` object containing the parsed data will be populated on the request object after the middleware, or undefined if there was no body to parse, the `Content-Type` was not matched, or an error occurred. To learn more about body parsing middleware visit the [@marblejs/middleware-body](../api-reference/middleware-body.md) API specification.
 
 {% hint style="danger" %}
-All properties and values in `req.body`object are untrusted and should be validated before trusting.
+All properties and values in `req.body`object are untrusted and should be validated before usage.
 {% endhint %}
 
 {% hint style="danger" %}
-By design, the `req.body, req.params, req.query`are type of `unknown`. In order to work with decoded values you should validate them before \(eg. using dedicated validator middleware\) or explictly assert attributes to the given type. We highly recommend to use the [@marblejs/middlware-io](../api-reference/middleware-io.md) package which allows you to properly infer the type of validated properties.
+By design, the `req.body, req.params, req.query`are of type `unknown`. In order to work with decoded values you should validate them before \(e.g. using dedicated validator middleware\) or explictly assert attributes to the given type. We highly recommend to use the [@marblejs/middlware-io](../api-reference/middleware-io.md) package which allows you to properly infer the type of validated properties.
 {% endhint %}
 
 ## URL parameters
@@ -115,7 +115,7 @@ const foo$ = r.pipe(
 );
 ```
 
-Decoded path parameters are placed in the `req.params` property. If there are no decoded URL parameters then the property contains an empty object. For the above example and route `/bob/12` the `req.params` object will contain the following parameters:
+Decoded path parameters are placed in the `req.params` property. If there are no decoded URL parameters then the property contains an empty object. For the above example and route `/bob/12` the `req.params` object will contain the following properties:
 
 ```typescript
 {
@@ -127,14 +127,14 @@ Decoded path parameters are placed in the `req.params` property. If there are no
 For parsing and decoding URL parameters, Marble.js makes use of [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp) library.
 
 {% hint style="danger" %}
-All properties and values in `req.params` object are untrusted and should be validated before trusting.
+All properties and values in `req.params` object are untrusted and should be validated before usage.
 {% endhint %}
 
 {% hint style="info" %}
 You should validate incoming URL params using dedicated [requestValidator$](../api-reference/middleware-io.md) middleware.
 {% endhint %}
 
-Path parameters can be suffixed with an asterisk \(`*`\) to denote a zero or more parameter matches. The code snippet below shows the example use case of "zero-or-more" parameter. For example, it can be useful for defining routing for static assets.
+Path parameters can be suffixed with an asterisk \(`*`\) to denote a zero or more parameter matches. The code snippet below shows an example use case of a "zero-or-more" parameter. For example, it can be useful for defining routing for static assets.
 
 {% code-tabs %}
 {% code-tabs-item title="getFile.effect.ts" %}
@@ -185,7 +185,7 @@ req.query = {
 ```
 
 {% hint style="danger" %}
-All properties and values in `req.query` object are untrusted and should be validated before trusting.
+All properties and values in `req.query` object are untrusted and should be validated before usage.
 {% endhint %}
 
 {% hint style="info" %}


### PR DESCRIPTION
I was going through the docs, saw some typos and grammar issues. The changes include adding "the"/"a"/"an" articles, fixing typos and some rephrasing.