### PR TITLE
changed filename to satisfy yarn start command

### DIFF
--- a/getting-started/quick-setup.md
+++ b/getting-started/quick-setup.md
@@ -56,7 +56,7 @@ export const api$ = r.pipe(
 To create Marble app instance, we can use [`createServer`](../other/api-reference/core/createserver.md), which is a wrapper around Node.js server creator with much more possibilities and goods inside. When created, it won't automatically start listening to given port and hostname until you call its awaited instance.
 
 {% tabs %}
-{% tab title="index.ts" %}
+{% tab title="server.ts" %}
 ```typescript
 import { createServer } from '@marblejs/core';
 import { IO } from 'fp-ts/lib/IO';


### PR DESCRIPTION
I noticed that if you follow the quick setup instructions, you create a file called `index.ts`, but use yarn to start a file called `server.ts`, which doesn't exist. Alternatively, you could replace the start script with:
```
"start": "ts-node index.ts"
```
but I feel that the name: `server.ts` tells you more about the code in the file, and should be kept.