### PR TITLE
yarn script server start fix

### DIFF
--- a/getting-started/quick-setup.md
+++ b/getting-started/quick-setup.md
@@ -92,7 +92,7 @@ Add the following script to your `package.json` file:
 
 ```javascript
 "scripts": {
-  "start": "ts-node server.ts"
+  "start": "ts-node index.ts"
 }
 ```
 


### PR DESCRIPTION
yarn script in packages.json should point to the file containing the creation of the server which in the instructions is called index.ts and not server.ts