### PR TITLE
chore: added missing comma in example

### DIFF
--- a/other/api-reference/middleware-body.md
+++ b/other/api-reference/middleware-body.md
@@ -80,7 +80,7 @@ export const login$ = r.pipe(
   r.matchPath('/login'),
   r.matchType('POST'),
   r.useEffect(req$ => req$.pipe(
-    map(req => req.body as { username: string, password: string })
+    map(req => req.body as { username: string, password: string }),
     map(body => ({ body: `Hello, ${body.username}!` }))
   )));
 ```


### PR DESCRIPTION
There was a missing comma in the example inside a `pipe` function