### PR TITLE
chore: removed misplaced commas

### DIFF
--- a/http/errors.md
+++ b/http/errors.md
@@ -64,8 +64,8 @@ import { mergeMap } from 'rxjs/operators';
 
 const authorize$: HttpMiddlewareEffect = req$ =>
   req$.pipe(
-    mergeMap(req => !isAuthorized(req),
-      ? throwError(new HttpError('Unauthorized', HttpStatus.UNAUTHORIZED)),
+    mergeMap(req => !isAuthorized(req)
+      ? throwError(new HttpError('Unauthorized', HttpStatus.UNAUTHORIZED))
       : of(req)),
   );
 ```


### PR DESCRIPTION
There were misplaced commas inside a ternary operator