### PR TITLE
chore: removed empty quote

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -2,8 +2,6 @@
 
 **Marble.js** requires node **v8.0** or higher:
 
->
-
 ```bash
 $ npm i @marblejs/core fp-ts rxjs
 ```


### PR DESCRIPTION
In the installation docs, there is a empty quote:

![image](https://user-images.githubusercontent.com/8608517/127753029-2ac00e63-9282-44e5-8ee3-12b1a4cc2c99.png)
